### PR TITLE
Enable captions for safety briefing

### DIFF
--- a/app/views/participants/safety_briefings/_video.html.erb
+++ b/app/views/participants/safety_briefings/_video.html.erb
@@ -16,9 +16,10 @@
           autoplay: 1,
           controls: <%= can?(:skip_safety_video, @participant) ? 1 : 0 %>,
           disablekb: <%= can?(:skip_safety_video, @participant) ? 0 : 1 %>,
-            modestbranding: 1,
+          modestbranding: 1,
           rel: 0,
           showinfo: 0,
+          cc_load_policy: 1,
         },
         events: {
           onReady: onPlayerReady,


### PR DESCRIPTION
The safety video is often watched in noisy environments.