### PR TITLE
Correct Message for Undo-Checkin

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -128,7 +128,7 @@ class CheckoutsController < ApplicationController
     checkout.checked_in_at = nil
     respond_to do |format|
       if checkout.save
-        format.html { redirect_to tool_path(checkout.tool), notice: 'Checkout was successfully undone' }
+        format.html { redirect_to tool_path(checkout.tool), notice: 'Checkin was successfully undone' }
       else
         format.html { redirect_to tool_path(checkout.tool), notice: 'Error' }
       end


### PR DESCRIPTION
This function undoes a tool check-in, but the message says it undoes a checkout. This fixes the message.