### PR TITLE
Added extra validations to PPE distribution applet so that:

### DIFF
--- a/app/controllers/applets/ppe_distribution_controller.rb
+++ b/app/controllers/applets/ppe_distribution_controller.rb
@@ -28,8 +28,11 @@ class Applets::PPEDistributionController < ApplicationController
     elsif @participant.organizations.blank?
       flash.now[:alert] = "#{@participant.name} has no organization memberships."
       return false
-    elsif Tool.hardhats.joins(:checkouts).where(checkouts: {participant_id: @participant.id, checked_in_at: nil}).exists?
-      flash.now[:alert] = "#{@participant.name} already has tools checked out."
+    elsif Tool.hardhats
+      .joins(:checkouts)
+      .where(checkouts: {participant_id: @participant.id, checked_in_at: nil})
+      .exists?
+      flash.now[:alert] = "#{@participant.name} already has a hardhat checked out."
       return false
     end
     true

--- a/app/controllers/applets/ppe_distribution_controller.rb
+++ b/app/controllers/applets/ppe_distribution_controller.rb
@@ -28,7 +28,7 @@ class Applets::PPEDistributionController < ApplicationController
     elsif @participant.organizations.blank?
       flash.now[:alert] = "#{@participant.name} has no organization memberships."
       return false
-    elsif !@participant.checkouts.current.blank?
+    elsif Tool.hardhats.joins(:checkouts).where(checkouts: {participant_id: @participant.id, checked_in_at: nil}).exists?
       flash.now[:alert] = "#{@participant.name} already has tools checked out."
       return false
     end

--- a/app/controllers/applets/ppe_distribution_controller.rb
+++ b/app/controllers/applets/ppe_distribution_controller.rb
@@ -28,6 +28,9 @@ class Applets::PPEDistributionController < ApplicationController
     elsif @participant.organizations.blank?
       flash.now[:alert] = "#{@participant.name} has no organization memberships."
       return false
+    elsif !@participant.checkouts.current.blank?
+      flash.now[:alert] = "#{@participant.name} already has tools checked out."
+      return false
     end
     true
   end
@@ -59,13 +62,32 @@ class Applets::PPEDistributionController < ApplicationController
                when :white
                  ToolType.find_by(name: 'Org Hardhat')
                end
-    @hardhat = Tool.create_with(tool_type: hh_type).find_or_create_by(barcode: params[:hardhat_search])
+    # Check if a hardhat exists with the given barcode
+    @hardhat = Tool.find_by(barcode: params[:hardhat_search])
+
+    # If it exists, check if it's the correct type
+    if @hardhat.present?
+      if @hardhat.tool_type != hh_type
+        flash.now[:alert] = 'Hardhat is not the correct type.'
+        return false
+      end
+    end
+
+    #  If hardhat doesn't exist create one
+    if @hardhat.blank?
+      @hardhat = Tool.create!(tool_type: hh_type, barcode: params[:hardhat_search])
+    end
+
     return false if @hardhat.blank?
     true
   end
 
   def step_three
-    @checkout = Checkout.create!(tool: @hardhat, participant: @participant, organization: @organization, checked_out_at: Time.now)
+    @checkout = Checkout.create(tool: @hardhat, participant: @participant, organization: @organization, checked_out_at: Time.now)
+    if !@checkout.save
+      flash.now[:alert] = "Checkout failed (#{@checkout.errors.full_messages.join(', ')})"
+      return false
+    end
     flash.now[:notice] = "Hardhat #{@hardhat.barcode} checked out to #{@participant.name} of #{@organization.name}. Review below or start over."
   end
 end

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -9,6 +9,7 @@ class Checkout < ApplicationRecord
 
   validates :checked_out_at, presence: true
   validates_associated :tool, :organization, :participant
+  validate :only_one_active_checkout_per_tool
 
   belongs_to :participant, touch: true
   belongs_to :organization, touch: true
@@ -19,4 +20,10 @@ class Checkout < ApplicationRecord
   scope :current, -> { where(checked_in_at: nil) }
   scope :active,       -> { where(active: true) }
   scope :inactive,     -> { where(active: false) }
+
+  def only_one_active_checkout_per_tool
+    if Checkout.where(tool_id: tool_id, checked_in_at: nil).where.not(id: id).exists?
+      errors.add(:tool_id, "already has an active checkout")
+    end
+  end
 end


### PR DESCRIPTION
a. A builder cannot get a hardhat if they already have a tool checked out (may be too broad
 b. No two checkouts can be active for the same tool.