### PR TITLE
Update all Rails 4.2 migrations to Rails 6.0

### DIFF
--- a/db/migrate/20130329192605_create_tools.rb
+++ b/db/migrate/20130329192605_create_tools.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateTools < ActiveRecord::Migration[4.2]
+class CreateTools < ActiveRecord::Migration[6.0]
   def change
     create_table :tools do |t|
       t.string :name, null: false

--- a/db/migrate/20130330002529_create_organization_categories.rb
+++ b/db/migrate/20130330002529_create_organization_categories.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateOrganizationCategories < ActiveRecord::Migration[4.2]
+class CreateOrganizationCategories < ActiveRecord::Migration[6.0]
   def change
     create_table :organization_categories do |t|
       t.string :name

--- a/db/migrate/20130330002630_create_organizations.rb
+++ b/db/migrate/20130330002630_create_organizations.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateOrganizations < ActiveRecord::Migration[4.2]
+class CreateOrganizations < ActiveRecord::Migration[6.0]
   def change
     create_table :organizations do |t|
       t.string :name
@@ -7,6 +7,5 @@ class CreateOrganizations < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :organizations, :organization_category_id
   end
 end

--- a/db/migrate/20130330003120_create_participants.rb
+++ b/db/migrate/20130330003120_create_participants.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateParticipants < ActiveRecord::Migration[4.2]
+class CreateParticipants < ActiveRecord::Migration[6.0]
   def change
     create_table :participants do |t|
       t.string :andrewid

--- a/db/migrate/20130330003207_create_memberships.rb
+++ b/db/migrate/20130330003207_create_memberships.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateMemberships < ActiveRecord::Migration[4.2]
+class CreateMemberships < ActiveRecord::Migration[6.0]
   def change
     create_table :memberships do |t|
       t.references :organization
@@ -8,7 +8,5 @@ class CreateMemberships < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :memberships, :organization_id
-    add_index :memberships, :participant_id
   end
 end

--- a/db/migrate/20130330003527_create_checkouts.rb
+++ b/db/migrate/20130330003527_create_checkouts.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateCheckouts < ActiveRecord::Migration[4.2]
+class CreateCheckouts < ActiveRecord::Migration[6.0]
   def change
     create_table :checkouts do |t|
       t.references :membership
@@ -9,7 +9,5 @@ class CreateCheckouts < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :checkouts, :membership_id
-    add_index :checkouts, :tool_id
   end
 end

--- a/db/migrate/20130330025330_add_has_signed_waiver_to_participants.rb
+++ b/db/migrate/20130330025330_add_has_signed_waiver_to_participants.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddHasSignedWaiverToParticipants < ActiveRecord::Migration[4.2]
+class AddHasSignedWaiverToParticipants < ActiveRecord::Migration[6.0]
   def change
     add_column :participants, :has_signed_waiver, :boolean
   end

--- a/db/migrate/20130330025433_remove_cardnumber_from_participants.rb
+++ b/db/migrate/20130330025433_remove_cardnumber_from_participants.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveCardnumberFromParticipants < ActiveRecord::Migration[4.2]
+class RemoveCardnumberFromParticipants < ActiveRecord::Migration[6.0]
   def up
     remove_column :participants, :cardnumber
   end

--- a/db/migrate/20130330031815_remove_tool_type_id_from_tools.rb
+++ b/db/migrate/20130330031815_remove_tool_type_id_from_tools.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveToolTypeIdFromTools < ActiveRecord::Migration[4.2]
+class RemoveToolTypeIdFromTools < ActiveRecord::Migration[6.0]
   def up
     remove_column :tools, :tool_type_id
   end

--- a/db/migrate/20130330032556_add_details_to_membership.rb
+++ b/db/migrate/20130330032556_add_details_to_membership.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddDetailsToMembership < ActiveRecord::Migration[4.2]
+class AddDetailsToMembership < ActiveRecord::Migration[6.0]
   def up
     add_column :memberships, :is_booth_chair, :boolean
     add_column :memberships, :title, :string

--- a/db/migrate/20130330033936_create_organization_aliases.rb
+++ b/db/migrate/20130330033936_create_organization_aliases.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateOrganizationAliases < ActiveRecord::Migration[4.2]
+class CreateOrganizationAliases < ActiveRecord::Migration[6.0]
   def change
     create_table :organization_aliases do |t|
       t.string :alias
@@ -7,7 +7,6 @@ class CreateOrganizationAliases < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :organization_aliases, :organization_id
     add_index :organization_aliases, :alias
   end
 end

--- a/db/migrate/20130330034634_create_shift_types.rb
+++ b/db/migrate/20130330034634_create_shift_types.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateShiftTypes < ActiveRecord::Migration[4.2]
+class CreateShiftTypes < ActiveRecord::Migration[6.0]
   def change
     create_table :shift_types do |t|
       t.string :name

--- a/db/migrate/20130330034708_create_shifts.rb
+++ b/db/migrate/20130330034708_create_shifts.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateShifts < ActiveRecord::Migration[4.2]
+class CreateShifts < ActiveRecord::Migration[6.0]
   def change
     create_table :shifts do |t|
       t.datetime :starts_at
@@ -10,6 +10,5 @@ class CreateShifts < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :shifts, :organization_id
   end
 end

--- a/db/migrate/20130330034910_create_shift_participants.rb
+++ b/db/migrate/20130330034910_create_shift_participants.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateShiftParticipants < ActiveRecord::Migration[4.2]
+class CreateShiftParticipants < ActiveRecord::Migration[6.0]
   def change
     create_table :shift_participants do |t|
       t.references :shift
@@ -9,7 +9,5 @@ class CreateShiftParticipants < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :shift_participants, :shift_id
-    add_index :shift_participants, :participant_id
   end
 end

--- a/db/migrate/20130330035301_create_charge_types.rb
+++ b/db/migrate/20130330035301_create_charge_types.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateChargeTypes < ActiveRecord::Migration[4.2]
+class CreateChargeTypes < ActiveRecord::Migration[6.0]
   def change
     create_table :charge_types do |t|
       t.string :name

--- a/db/migrate/20130330035812_create_charges.rb
+++ b/db/migrate/20130330035812_create_charges.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateCharges < ActiveRecord::Migration[4.2]
+class CreateCharges < ActiveRecord::Migration[6.0]
   def change
     create_table :charges do |t|
       t.references :organization
@@ -12,6 +12,5 @@ class CreateCharges < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :charges, :organization_id
   end
 end

--- a/db/migrate/20130404195645_rename_column_in_organization_alias.rb
+++ b/db/migrate/20130404195645_rename_column_in_organization_alias.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RenameColumnInOrganizationAlias < ActiveRecord::Migration[4.2]
+class RenameColumnInOrganizationAlias < ActiveRecord::Migration[6.0]
   def up
     rename_column :organization_aliases, :alias, :name
   end

--- a/db/migrate/20130405182245_add_phone_number_to_participant.rb
+++ b/db/migrate/20130405182245_add_phone_number_to_participant.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddPhoneNumberToParticipant < ActiveRecord::Migration[4.2]
+class AddPhoneNumberToParticipant < ActiveRecord::Migration[6.0]
   def change
     add_column :participants, :phone_number, :string
   end

--- a/db/migrate/20130406194442_add_charged_at_to_charge.rb
+++ b/db/migrate/20130406194442_add_charged_at_to_charge.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddChargedAtToCharge < ActiveRecord::Migration[4.2]
+class AddChargedAtToCharge < ActiveRecord::Migration[6.0]
   def change
     add_column :charges, :charged_at, :datetime
   end

--- a/db/migrate/20130406234724_create_task_statuses.rb
+++ b/db/migrate/20130406234724_create_task_statuses.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateTaskStatuses < ActiveRecord::Migration[4.2]
+class CreateTaskStatuses < ActiveRecord::Migration[6.0]
   def change
     create_table :task_statuses do |t|
       t.string :name

--- a/db/migrate/20130406234921_create_tasks.rb
+++ b/db/migrate/20130406234921_create_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateTasks < ActiveRecord::Migration[4.2]
+class CreateTasks < ActiveRecord::Migration[6.0]
   def change
     create_table :tasks do |t|
       t.datetime :due_at
@@ -11,6 +11,5 @@ class CreateTasks < ActiveRecord::Migration[4.2]
 
       t.timestamps
     end
-    add_index :tasks, :task_status_id
   end
 end

--- a/db/migrate/20130410015851_change_display_duration_in_tasks.rb
+++ b/db/migrate/20130410015851_change_display_duration_in_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class ChangeDisplayDurationInTasks < ActiveRecord::Migration[4.2]
+class ChangeDisplayDurationInTasks < ActiveRecord::Migration[6.0]
   def up
     remove_column :tasks, :display_duration
     add_column :tasks, :display_duration, :datetime

--- a/db/migrate/20130410024915_add_has_signed_hardhat_waiver_to_participant.rb
+++ b/db/migrate/20130410024915_add_has_signed_hardhat_waiver_to_participant.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddHasSignedHardhatWaiverToParticipant < ActiveRecord::Migration[4.2]
+class AddHasSignedHardhatWaiverToParticipant < ActiveRecord::Migration[6.0]
   def change
     add_column :participants, :has_signed_hardhat_waiver, :boolean
   end

--- a/db/migrate/20130410030423_add_booth_chair_order_to_membership.rb
+++ b/db/migrate/20130410030423_add_booth_chair_order_to_membership.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddBoothChairOrderToMembership < ActiveRecord::Migration[4.2]
+class AddBoothChairOrderToMembership < ActiveRecord::Migration[6.0]
   def change
     add_column :memberships, :booth_chair_order, :integer
   end

--- a/db/migrate/20130410053347_replace_membership_with_participant_and_organization_in_checkouts.rb
+++ b/db/migrate/20130410053347_replace_membership_with_participant_and_organization_in_checkouts.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class ReplaceMembershipWithParticipantAndOrganizationInCheckouts < ActiveRecord::Migration[4.2]
+class ReplaceMembershipWithParticipantAndOrganizationInCheckouts < ActiveRecord::Migration[6.0]
   def change
     add_column :checkouts, :participant_id, :integer
     add_column :checkouts, :organization_id, :integer

--- a/db/migrate/20130910031601_create_documents.rb
+++ b/db/migrate/20130910031601_create_documents.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateDocuments < ActiveRecord::Migration[4.2]
+class CreateDocuments < ActiveRecord::Migration[6.0]
   def change
     create_table :documents do |t|
       t.integer :document_id

--- a/db/migrate/20130910223616_create_faqs.rb
+++ b/db/migrate/20130910223616_create_faqs.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateFaqs < ActiveRecord::Migration[4.2]
+class CreateFaqs < ActiveRecord::Migration[6.0]
   def change
     create_table :faqs do |t|
       t.text :question

--- a/db/migrate/20130921014557_create_contact_lists.rb
+++ b/db/migrate/20130921014557_create_contact_lists.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateContactLists < ActiveRecord::Migration[4.2]
+class CreateContactLists < ActiveRecord::Migration[6.0]
   def change
     create_table :contact_lists do |t|
       t.integer :participant_id

--- a/db/migrate/20131015222205_add_created_by_to_tasks.rb
+++ b/db/migrate/20131015222205_add_created_by_to_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddCreatedByToTasks < ActiveRecord::Migration[4.2]
+class AddCreatedByToTasks < ActiveRecord::Migration[6.0]
   def change
     add_column :tasks, :created_by, :integer
   end

--- a/db/migrate/20131015222431_add_assigned_person_to_tasks.rb
+++ b/db/migrate/20131015222431_add_assigned_person_to_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddAssignedPersonToTasks < ActiveRecord::Migration[4.2]
+class AddAssignedPersonToTasks < ActiveRecord::Migration[6.0]
   def change
     add_column :tasks, :assigned_person, :integer
   end

--- a/db/migrate/20131015231409_add_task_category_to_tasks.rb
+++ b/db/migrate/20131015231409_add_task_category_to_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddTaskCategoryToTasks < ActiveRecord::Migration[4.2]
+class AddTaskCategoryToTasks < ActiveRecord::Migration[6.0]
   def change
     add_column :tasks, :task_category_id, :integer
   end

--- a/db/migrate/20131018042733_create_task_categories.rb
+++ b/db/migrate/20131018042733_create_task_categories.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateTaskCategories < ActiveRecord::Migration[4.2]
+class CreateTaskCategories < ActiveRecord::Migration[6.0]
   def change
     create_table :task_categories do |t|
       t.string :name

--- a/db/migrate/20131117052524_add_info_to_particiapants.rb
+++ b/db/migrate/20131117052524_add_info_to_particiapants.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddInfoToParticiapants < ActiveRecord::Migration[4.2]
+class AddInfoToParticiapants < ActiveRecord::Migration[6.0]
   def change
     add_column :participants, :cached_name, :string
     add_column :participants, :cached_surname, :string

--- a/db/migrate/20131216082238_drop_task_categories.rb
+++ b/db/migrate/20131216082238_drop_task_categories.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DropTaskCategories < ActiveRecord::Migration[4.2]
+class DropTaskCategories < ActiveRecord::Migration[6.0]
   def change
     remove_reference :tasks, :task_category
     drop_table :task_categories

--- a/db/migrate/20131216083435_remove_columns_from_tasks.rb
+++ b/db/migrate/20131216083435_remove_columns_from_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveColumnsFromTasks < ActiveRecord::Migration[4.2]
+class RemoveColumnsFromTasks < ActiveRecord::Migration[6.0]
   def change
     remove_column :tasks, :assigned_person, :integer
     remove_column :tasks, :created_by, :integer

--- a/db/migrate/20131216083914_drop_task_status_table.rb
+++ b/db/migrate/20131216083914_drop_task_status_table.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DropTaskStatusTable < ActiveRecord::Migration[4.2]
+class DropTaskStatusTable < ActiveRecord::Migration[6.0]
   def change
     remove_reference :tasks, :task_status
     drop_table :task_statuses

--- a/db/migrate/20131229225058_create_organization_status_types.rb
+++ b/db/migrate/20131229225058_create_organization_status_types.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateOrganizationStatusTypes < ActiveRecord::Migration[4.2]
+class CreateOrganizationStatusTypes < ActiveRecord::Migration[6.0]
   def change
     create_table :organization_status_types do |t|
       t.string :name

--- a/db/migrate/20131229233330_remove_clocked_out_at_from_shift_participants.rb
+++ b/db/migrate/20131229233330_remove_clocked_out_at_from_shift_participants.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveClockedOutAtFromShiftParticipants < ActiveRecord::Migration[4.2]
+class RemoveClockedOutAtFromShiftParticipants < ActiveRecord::Migration[6.0]
   def change
     remove_column :shift_participants, :clocked_out_at, :datetime
   end

--- a/db/migrate/20140101213349_add_fields_to_documents.rb
+++ b/db/migrate/20140101213349_add_fields_to_documents.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddFieldsToDocuments < ActiveRecord::Migration[4.2]
+class AddFieldsToDocuments < ActiveRecord::Migration[6.0]
   def change
     add_column :documents, :organization_id, :integer
     add_column :documents, :public, :boolean

--- a/db/migrate/20140102034118_create_downtime_entries.rb
+++ b/db/migrate/20140102034118_create_downtime_entries.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateDowntimeEntries < ActiveRecord::Migration[4.2]
+class CreateDowntimeEntries < ActiveRecord::Migration[6.0]
   def change
     create_table :downtime_entries do |t|
       t.datetime :started_at

--- a/db/migrate/20140102035212_add_approved_to_charges.rb
+++ b/db/migrate/20140102035212_add_approved_to_charges.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddApprovedToCharges < ActiveRecord::Migration[4.2]
+class AddApprovedToCharges < ActiveRecord::Migration[6.0]
   def change
     add_column :charges, :approved, :boolean
   end

--- a/db/migrate/20140103202926_delete_contact_list_table.rb
+++ b/db/migrate/20140103202926_delete_contact_list_table.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DeleteContactListTable < ActiveRecord::Migration[4.2]
+class DeleteContactListTable < ActiveRecord::Migration[6.0]
   def change
     drop_table :contact_lists
   end

--- a/db/migrate/20140103210420_add_is_approved_to_charges.rb
+++ b/db/migrate/20140103210420_add_is_approved_to_charges.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddIsApprovedToCharges < ActiveRecord::Migration[4.2]
+class AddIsApprovedToCharges < ActiveRecord::Migration[6.0]
   def change
     add_column :charges, :is_approved, :boolean
   end

--- a/db/migrate/20140313071315_add_short_name_to_organization.rb
+++ b/db/migrate/20140313071315_add_short_name_to_organization.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddShortNameToOrganization < ActiveRecord::Migration[4.2]
+class AddShortNameToOrganization < ActiveRecord::Migration[6.0]
   def change
     add_column :organizations, :short_name, :string
   end

--- a/db/migrate/20140313071351_add_short_name_to_shift_type.rb
+++ b/db/migrate/20140313071351_add_short_name_to_shift_type.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddShortNameToShiftType < ActiveRecord::Migration[4.2]
+class AddShortNameToShiftType < ActiveRecord::Migration[6.0]
   def change
     add_column :shift_types, :short_name, :string
   end

--- a/db/migrate/20140313072303_remove_approved_from_charges.rb
+++ b/db/migrate/20140313072303_remove_approved_from_charges.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveApprovedFromCharges < ActiveRecord::Migration[4.2]
+class RemoveApprovedFromCharges < ActiveRecord::Migration[6.0]
   def change
     remove_column :charges, :approved, :boolean
   end

--- a/db/migrate/20140329073210_add_creating_participant_to_charges.rb
+++ b/db/migrate/20140329073210_add_creating_participant_to_charges.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddCreatingParticipantToCharges < ActiveRecord::Migration[4.2]
+class AddCreatingParticipantToCharges < ActiveRecord::Migration[6.0]
   def change
     add_column :charges, :creating_participant_id, :integer
   end

--- a/db/migrate/20140331214943_create_organization_timeline_entry_types.rb
+++ b/db/migrate/20140331214943_create_organization_timeline_entry_types.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateOrganizationTimelineEntryTypes < ActiveRecord::Migration[4.2]
+class CreateOrganizationTimelineEntryTypes < ActiveRecord::Migration[6.0]
   def change
     create_table :organization_timeline_entry_types do |t|
       t.string :name

--- a/db/migrate/20140331215328_create_organization_timeline_entries.rb
+++ b/db/migrate/20140331215328_create_organization_timeline_entries.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
-class CreateOrganizationTimelineEntries < ActiveRecord::Migration[4.2]
+class CreateOrganizationTimelineEntries < ActiveRecord::Migration[6.0]
   def change
     create_table :organization_timeline_entries do |t|
       t.datetime :started_at
       t.datetime :ended_at
-      t.references :organization_timeline_entry_type
+      t.references :organization_timeline_entry_type, index: { name: 'index_timeline_entries_on_type' }
       t.references :organization, index: true
       t.text :description
 
       t.timestamps
     end
-
-    add_index :organization_timeline_entries, :organization_timeline_entry_type_id,
-              name: 'index_timeline_entries_on_type'
   end
 end

--- a/db/migrate/20140331224212_drop_downtime_entries.rb
+++ b/db/migrate/20140331224212_drop_downtime_entries.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DropDowntimeEntries < ActiveRecord::Migration[4.2]
+class DropDowntimeEntries < ActiveRecord::Migration[6.0]
   def up
     drop_table :downtime_entries
   end

--- a/db/migrate/20140409165006_add_description_to_shifts.rb
+++ b/db/migrate/20140409165006_add_description_to_shifts.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddDescriptionToShifts < ActiveRecord::Migration[4.2]
+class AddDescriptionToShifts < ActiveRecord::Migration[6.0]
   def change
     add_column :shifts, :description, :string
   end

--- a/db/migrate/20150112202427_create_store_items.rb
+++ b/db/migrate/20150112202427_create_store_items.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateStoreItems < ActiveRecord::Migration[4.2]
+class CreateStoreItems < ActiveRecord::Migration[6.0]
   def change
     create_table :store_items do |t|
       t.string :name

--- a/db/migrate/20150112202901_create_store_purchases.rb
+++ b/db/migrate/20150112202901_create_store_purchases.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateStorePurchases < ActiveRecord::Migration[4.2]
+class CreateStorePurchases < ActiveRecord::Migration[6.0]
   def change
     create_table :store_purchases do |t|
       t.references :charge, index: true

--- a/db/migrate/20150219063415_create_judges.rb
+++ b/db/migrate/20150219063415_create_judges.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateJudges < ActiveRecord::Migration[4.2]
+class CreateJudges < ActiveRecord::Migration[6.0]
   def change
     create_table :judges do |t|
       t.string :name

--- a/db/migrate/20150219063834_create_judgement_categories.rb
+++ b/db/migrate/20150219063834_create_judgement_categories.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateJudgementCategories < ActiveRecord::Migration[4.2]
+class CreateJudgementCategories < ActiveRecord::Migration[6.0]
   def change
     create_table :judgement_categories do |t|
       t.integer :grouping

--- a/db/migrate/20150219064158_create_judgements.rb
+++ b/db/migrate/20150219064158_create_judgements.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateJudgements < ActiveRecord::Migration[4.2]
+class CreateJudgements < ActiveRecord::Migration[6.0]
   def change
     create_table :judgements do |t|
       t.references :judgement_category, index: true

--- a/db/migrate/20150222001013_change_organization_timeline_entry_type_to_enum.rb
+++ b/db/migrate/20150222001013_change_organization_timeline_entry_type_to_enum.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class ChangeOrganizationTimelineEntryTypeToEnum < ActiveRecord::Migration[4.2]
+class ChangeOrganizationTimelineEntryTypeToEnum < ActiveRecord::Migration[6.0]
   def change
     remove_column :organization_timeline_entries, :organization_timeline_entry_type_id, :integer
     add_column :organization_timeline_entries, :entry_type, :integer

--- a/db/migrate/20150401144232_create_phone_carriers.rb
+++ b/db/migrate/20150401144232_create_phone_carriers.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreatePhoneCarriers < ActiveRecord::Migration[4.2]
+class CreatePhoneCarriers < ActiveRecord::Migration[6.0]
   def change
     create_table :phone_carriers do |t|
       t.string :name

--- a/db/migrate/20150401144320_add_phone_carrier_to_participant.rb
+++ b/db/migrate/20150401144320_add_phone_carrier_to_participant.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddPhoneCarrierToParticipant < ActiveRecord::Migration[4.2]
+class AddPhoneCarrierToParticipant < ActiveRecord::Migration[6.0]
   def change
     add_reference :participants, :phone_carrier, index: true
     add_foreign_key :participants, :phone_carriers

--- a/db/migrate/20160208180159_create_tool_types.rb
+++ b/db/migrate/20160208180159_create_tool_types.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateToolTypes < ActiveRecord::Migration[4.2]
+class CreateToolTypes < ActiveRecord::Migration[6.0]
   def change
     create_table :tool_types do |t|
       t.string :name

--- a/db/migrate/20160208180433_add_tool_types_remove_tool_name.rb
+++ b/db/migrate/20160208180433_add_tool_types_remove_tool_name.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddToolTypesRemoveToolName < ActiveRecord::Migration[4.2]
+class AddToolTypesRemoveToolName < ActiveRecord::Migration[6.0]
   def change
     add_reference :tools, :tool_type, index: true, foreign_key: true
     remove_column :tools, :name, :string

--- a/db/migrate/20160215065501_create_tool_waitlists.rb
+++ b/db/migrate/20160215065501_create_tool_waitlists.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateToolWaitlists < ActiveRecord::Migration[4.2]
+class CreateToolWaitlists < ActiveRecord::Migration[6.0]
   def change
     create_table :tool_waitlists do |t|
       t.references :tool_type, index: true

--- a/db/migrate/20160404161512_create_event_log.rb
+++ b/db/migrate/20160404161512_create_event_log.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateEventLog < ActiveRecord::Migration[4.2]
+class CreateEventLog < ActiveRecord::Migration[6.0]
   def change
     create_table :events, force: :cascade do |t|
       t.boolean  :is_done

--- a/db/migrate/20170305040259_add_waiver_start_to_participant.rb
+++ b/db/migrate/20170305040259_add_waiver_start_to_participant.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddWaiverStartToParticipant < ActiveRecord::Migration[4.2]
+class AddWaiverStartToParticipant < ActiveRecord::Migration[6.0]
   def change
     add_column :participants, :waiver_start, :datetime
   end

--- a/db/migrate/20170321154121_create_certification_types.rb
+++ b/db/migrate/20170321154121_create_certification_types.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateCertificationTypes < ActiveRecord::Migration[4.2]
+class CreateCertificationTypes < ActiveRecord::Migration[6.0]
   def change
     create_table :certification_types do |t|
       t.string :name

--- a/db/migrate/20170321154153_create_certifications.rb
+++ b/db/migrate/20170321154153_create_certifications.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateCertifications < ActiveRecord::Migration[4.2]
+class CreateCertifications < ActiveRecord::Migration[6.0]
   def change
     create_table :certifications do |t|
       t.belongs_to :participant, index: true, foreign_key: true

--- a/db/migrate/20170322031706_create_tool_type_certifications.rb
+++ b/db/migrate/20170322031706_create_tool_type_certifications.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateToolTypeCertifications < ActiveRecord::Migration[4.2]
+class CreateToolTypeCertifications < ActiveRecord::Migration[6.0]
   def change
     create_table :tool_type_certifications do |t|
       t.belongs_to :tool_type, index: true, foreign_key: true

--- a/db/migrate/20170323163001_change_store_item_price_datatype.rb
+++ b/db/migrate/20170323163001_change_store_item_price_datatype.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class ChangeStoreItemPriceDatatype < ActiveRecord::Migration[4.2]
+class ChangeStoreItemPriceDatatype < ActiveRecord::Migration[6.0]
   def change
     change_column :store_items, :price, :decimal, precision: 8, scale: 2
     change_column :store_purchases, :price_at_purchase, :decimal, precision: 8, scale: 2

--- a/db/migrate/20170326233627_create_delayed_jobs.rb
+++ b/db/migrate/20170326233627_create_delayed_jobs.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateDelayedJobs < ActiveRecord::Migration[4.2]
+class CreateDelayedJobs < ActiveRecord::Migration[6.0]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20170402012413_add_participant_id_to_events.rb
+++ b/db/migrate/20170402012413_add_participant_id_to_events.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddParticipantIdToEvents < ActiveRecord::Migration[4.2]
+class AddParticipantIdToEvents < ActiveRecord::Migration[6.0]
   def change
     add_column :events, :participant_id, :integer
   end

--- a/db/migrate/20170410184313_add_is_building_to_organization_category.rb
+++ b/db/migrate/20170410184313_add_is_building_to_organization_category.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddIsBuildingToOrganizationCategory < ActiveRecord::Migration[4.2]
+class AddIsBuildingToOrganizationCategory < ActiveRecord::Migration[6.0]
   def change
     add_column :organization_categories, :is_building, :boolean
   end

--- a/db/migrate/20190227041337_drop_phone_carrier.rb
+++ b/db/migrate/20190227041337_drop_phone_carrier.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DropPhoneCarrier < ActiveRecord::Migration[4.2]
+class DropPhoneCarrier < ActiveRecord::Migration[6.0]
   def change
     remove_reference :participants, :phone_carrier, index: true, foreign_key: true
     drop_table :phone_carriers

--- a/db/migrate/20190227204757_recreate_delayed_jobs.rb
+++ b/db/migrate/20190227204757_recreate_delayed_jobs.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RecreateDelayedJobs < ActiveRecord::Migration[4.2][4.2]
+class RecreateDelayedJobs < ActiveRecord::Migration[6.0]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20190313013806_drop_documents.rb
+++ b/db/migrate/20190313013806_drop_documents.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DropDocuments < ActiveRecord::Migration[4.2]
+class DropDocuments < ActiveRecord::Migration[6.0]
   def change
     drop_table :documents
   end

--- a/db/migrate/20190313163240_drop_judgements.rb
+++ b/db/migrate/20190313163240_drop_judgements.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DropJudgements < ActiveRecord::Migration[4.2]
+class DropJudgements < ActiveRecord::Migration[6.0]
   def change
     remove_reference :judgements, :judge
     remove_reference :judgements, :judgement_category

--- a/db/migrate/20190320032323_drop_tool_waitlists.rb
+++ b/db/migrate/20190320032323_drop_tool_waitlists.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class DropToolWaitlists < ActiveRecord::Migration[4.2]
+class DropToolWaitlists < ActiveRecord::Migration[6.0]
   def change
     drop_table :tool_waitlists
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,15 +13,15 @@
 ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
   create_table "certification_types", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "certifications", force: :cascade do |t|
     t.integer "participant_id"
     t.integer "certification_type_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["certification_type_id"], name: "index_certifications_on_certification_type_id"
     t.index ["participant_id"], name: "index_certifications_on_participant_id"
   end
@@ -31,8 +31,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.boolean "requires_booth_chair_approval"
     t.decimal "default_amount", precision: 8, scale: 2
     t.text "description"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "charges", force: :cascade do |t|
@@ -42,11 +42,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.text "description"
     t.integer "issuing_participant_id"
     t.integer "receiving_participant_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "charged_at", precision: nil
     t.boolean "is_approved"
     t.integer "creating_participant_id"
+    t.index ["charge_type_id"], name: "index_charges_on_charge_type_id"
     t.index ["organization_id"], name: "index_charges_on_organization_id"
   end
 
@@ -54,8 +55,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.integer "tool_id"
     t.datetime "checked_out_at", precision: nil
     t.datetime "checked_in_at", precision: nil
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "participant_id"
     t.integer "organization_id"
     t.index ["tool_id"], name: "index_checkouts_on_tool_id"
@@ -71,8 +72,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.datetime "failed_at", precision: nil
     t.string "locked_by"
     t.string "queue"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
@@ -93,8 +94,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
   create_table "faq", force: :cascade do |t|
     t.text "question"
     t.text "answer"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "organization_category_id"
     t.index ["organization_category_id"], name: "index_faq_on_organization_category_id"
   end
@@ -102,8 +103,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
   create_table "memberships", force: :cascade do |t|
     t.integer "organization_id"
     t.integer "participant_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "is_booth_chair"
     t.string "title"
     t.integer "booth_chair_order"
@@ -129,8 +130,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
   create_table "organization_aliases", force: :cascade do |t|
     t.string "name"
     t.integer "organization_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["name"], name: "index_organization_aliases_on_name"
     t.index ["organization_id"], name: "index_organization_aliases_on_organization_id"
   end
@@ -161,8 +162,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
 
   create_table "organization_categories", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "building"
     t.string "lookup_key"
     t.index ["name"], name: "index_organization_categories_on_name", unique: true
@@ -178,31 +179,31 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.datetime "ended_at", precision: nil
     t.integer "organization_id"
     t.text "description"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "entry_type"
     t.index ["organization_id"], name: "index_organization_timeline_entries_on_organization_id"
   end
 
   create_table "organization_timeline_entry_types", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "organizations", force: :cascade do |t|
     t.string "name"
     t.integer "organization_category_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "short_name"
     t.index ["organization_category_id"], name: "index_organizations_on_organization_category_id"
   end
 
   create_table "participants", force: :cascade do |t|
     t.string "eppn"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "signed_waiver"
     t.string "phone_number"
     t.string "cached_name"
@@ -241,16 +242,16 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.integer "shift_id"
     t.integer "participant_id"
     t.datetime "clocked_in_at", precision: nil
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["participant_id"], name: "index_shift_participants_on_participant_id"
     t.index ["shift_id"], name: "index_shift_participants_on_shift_id"
   end
 
   create_table "shift_types", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "short_name"
   end
 
@@ -260,18 +261,19 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.integer "required_number_of_participants"
     t.integer "organization_id"
     t.integer "shift_type_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "description"
     t.index ["organization_id"], name: "index_shifts_on_organization_id"
+    t.index ["shift_type_id"], name: "index_shifts_on_shift_type_id"
   end
 
   create_table "store_items", force: :cascade do |t|
     t.string "name"
     t.decimal "price", precision: 8, scale: 2
     t.integer "quantity"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "store_purchases", force: :cascade do |t|
@@ -279,8 +281,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.integer "store_item_id"
     t.decimal "price_at_purchase", precision: 8, scale: 2
     t.integer "quantity_purchased"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["charge_id"], name: "index_store_purchases_on_charge_id"
     t.index ["store_item_id"], name: "index_store_purchases_on_store_item_id"
   end
@@ -290,8 +292,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
     t.integer "completed_by_id"
     t.string "name"
     t.text "description"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "is_completed"
   end
 
@@ -316,23 +318,23 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_11_170820) do
   create_table "tool_type_certifications", force: :cascade do |t|
     t.integer "tool_type_id"
     t.integer "certification_type_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["certification_type_id"], name: "index_tool_type_certifications_on_certification_type_id"
     t.index ["tool_type_id"], name: "index_tool_type_certifications_on_tool_type_id"
   end
 
   create_table "tool_types", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tools", force: :cascade do |t|
     t.integer "barcode"
     t.text "description"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "tool_type_id"
     t.boolean "active"
     t.index ["barcode"], name: "index_tools_on_barcode"

--- a/docker/production/entrypoint.sh
+++ b/docker/production/entrypoint.sh
@@ -5,11 +5,16 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f ./tmp/pids/server.pid
 
-# Make sure db is ready to go
-# TODO: uncomment once we migrate development DB to MySQL
-# This line fails because of differences between SQLite (where migrations were created)
-# and production MySQL 
-# bundle exec rails db:migrate
-
 # Then exec the container's main process (CMD in the Dockerfile).
 exec "$@"
+
+# Note: You will have to run rails db:migrate yourself when creating a new
+# production container. We do not run it automatically on container startup
+# because our development database (SQLite3) could potentially generate
+# migrations that don't work in production (MySQL2). If this occurs, it is
+# easier to debug the issue if the container remains up despite the failure.
+#
+# To run db:migrate, run these commands in the production virtual machine:
+#
+# $ podman exec -it binder bash
+# > rails db:migrate

--- a/test/fixtures/tools.yml
+++ b/test/fixtures/tools.yml
@@ -250,7 +250,7 @@
    id: 32
    barcode: 2716
    description: HDX
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -266,47 +266,37 @@
    id: 34
    barcode: 2594
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-02 06:11:47
 35:
    id: 35
    barcode: 1639
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-13 21:49:43
 36:
    id: 36
    barcode: 2081
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 15:30:19
 37:
    id: 37
    barcode: 2591
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2019-04-11 15:29:30
 38:
    id: 38
    barcode: 2593
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 15:43:54
 39:
    id: 39
    barcode: 2391
    description: Swanson
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 7
@@ -330,7 +320,7 @@
    id: 42
    barcode: 2603
    description: HDX
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -354,9 +344,7 @@
    id: 45
    barcode: 1625
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 15:20:10
 46:
    id: 46
@@ -378,7 +366,7 @@
    id: 48
    barcode: 2033
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -394,7 +382,7 @@
    id: 50
    barcode: 2601
    description: Bayco
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -418,7 +406,7 @@
    id: 53
    barcode: 2604
    description: HDX
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -426,7 +414,7 @@
    id: 54
    barcode: 3381
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -434,7 +422,7 @@
    id: 55
    barcode: 2103
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -522,7 +510,7 @@
    id: 66
    barcode: 2155
    description: 2' Empire
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 10
@@ -538,7 +526,7 @@
    id: 68
    barcode: 3338
    description: HDX
-   created_at: Light
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 6
@@ -1002,7 +990,7 @@
    id: 126
    barcode: 3347
    description: Dewalt 18v - Bad battery
-   created_at: will be destroyed
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:56
    tool_type_id: WTF
    active: 15
@@ -1018,47 +1006,37 @@
    id: 128
    barcode: 2088
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2019-04-23 16:59:26
 129:
    id: 129
    barcode: 2084
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 14:18:57
 130:
    id: 130
    barcode: 2085
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 17:58:33
 131:
    id: 131
    barcode: 3350
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-05 05:16:57
 132:
    id: 132
    barcode: 2080
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 15:19:01
 133:
    id: 133
    barcode: 2351
    description: Kobalt
-   created_at: Blue
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 16
@@ -1122,7 +1100,7 @@
    id: 141
    barcode: 1944
    description: Task Force
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 21
@@ -1138,7 +1116,7 @@
    id: 143
    barcode: 2363
    description: Stanely TR-45
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 22
@@ -1322,7 +1300,7 @@
    id: 166
    barcode: 1651
    description: Arrow T-50
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 22
@@ -1330,7 +1308,7 @@
    id: 167
    barcode: 2622
    description: Arrow T-50
-   created_at: Silver — BROKEN
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 22
@@ -1346,7 +1324,7 @@
    id: 169
    barcode: 3365
    description: Arrow T-50
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 22
@@ -1354,7 +1332,7 @@
    id: 170
    barcode: 2565
    description: Klein
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 27
@@ -1386,7 +1364,7 @@
    id: 174
    barcode: 2626
    description: 25' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 17
@@ -1450,7 +1428,7 @@
    id: 182
    barcode: 2179
    description: SkyMate
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 28
@@ -1490,7 +1468,7 @@
    id: 187
    barcode: 2384
    description: Black & Decker
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 10
@@ -1498,7 +1476,7 @@
    id: 188
    barcode: 2392
    description: Swanson
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 7
@@ -1506,7 +1484,7 @@
    id: 189
    barcode: 2092
    description: Swanson
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 7
@@ -1514,7 +1492,7 @@
    id: 190
    barcode: 2091
    description: Swanson
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 7
@@ -1538,7 +1516,7 @@
    id: 193
    barcode: 1616
    description: Porter-Cable
-   created_at: Gray
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 32
@@ -1554,7 +1532,7 @@
    id: 195
    barcode: 2002
    description: Swanson
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 7
@@ -1562,7 +1540,7 @@
    id: 196
    barcode: 2003
    description: Swanson
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 7
@@ -1626,17 +1604,13 @@
    id: 204
    barcode: 2609
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 15:49:11
 205:
    id: 205
    barcode: 2610
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-07 15:20:53
 206:
    id: 206
@@ -1674,7 +1648,7 @@
    id: 210
    barcode: 1964
    description: Kobalt
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 35
@@ -1690,7 +1664,7 @@
    id: 212
    barcode: 2146
    description: Defiant
-   created_at: Red Headlamp
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 6
@@ -1698,7 +1672,7 @@
    id: 213
    barcode: 1963
    description: Kobalt
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 35
@@ -1722,15 +1696,13 @@
    id: 216
    barcode: 1996
    description: Kobalt
-   created_at: Mini
-   updated_at: Red & Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2019-04-14 20:17:21
 217:
    id: 217
    barcode: 1970
    description: Kobalt
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 35
@@ -1770,7 +1742,7 @@
    id: 222
    barcode: 1965
    description: Kobalt
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 35
@@ -2066,7 +2038,7 @@
    id: 259
    barcode: 3394
    description: Gorilla Ladder
-   created_at: extends to 18 feet
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 34
@@ -2074,7 +2046,7 @@
    id: 260
    barcode: 3395
    description: 10’ orange
-   created_at: warner
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 34
@@ -2130,7 +2102,7 @@
    id: 267
    barcode: 2385
    description: 200' Lufkin
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 17
@@ -2218,7 +2190,7 @@
    id: 278
    barcode: 1652
    description: Arrow T-50
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 22
@@ -2234,7 +2206,7 @@
    id: 280
    barcode: 2630
    description: HDX
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 48
@@ -2242,7 +2214,7 @@
    id: 281
    barcode: 1947
    description: Task Force
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-03 15:19:57
    tool_type_id: WTF
    active: 26
@@ -15826,9 +15798,7 @@
    id: 2671
    barcode: 3570
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-08 04:36:13
 2672:
    id: 2672
@@ -15874,7 +15844,7 @@
    id: 2677
    barcode: 6001
    description: January
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2023-03-14 22:22:17
    tool_type_id: 55
    active: 1
@@ -15882,7 +15852,7 @@
    id: 2678
    barcode: 6002
    description: February
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-28 23:48:10
    tool_type_id: 55
    active: 1
@@ -15890,7 +15860,7 @@
    id: 2679
    barcode: 6003
    description: March (wire issue)
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-07 18:31:49
    tool_type_id: 55
    active: 1
@@ -15898,7 +15868,7 @@
    id: 2680
    barcode: 6005
    description: May
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-10 19:53:40
    tool_type_id: 55
    active: 1
@@ -15906,7 +15876,7 @@
    id: 2681
    barcode: 6006
    description: June
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-28 23:48:27
    tool_type_id: 55
    active: 1
@@ -15914,7 +15884,7 @@
    id: 2682
    barcode: 6007
    description: July
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-28 23:48:35
    tool_type_id: 55
    active: 1
@@ -15922,7 +15892,7 @@
    id: 2683
    barcode: 6008
    description: August
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-28 23:48:42
    tool_type_id: 55
    active: 1
@@ -15930,7 +15900,7 @@
    id: 2684
    barcode: 6009
    description: September
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-11 15:17:36
    tool_type_id: 55
    active: 1
@@ -15938,7 +15908,7 @@
    id: 2685
    barcode: 6010
    description: October
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-28 23:48:50
    tool_type_id: 55
    active: 1
@@ -15946,7 +15916,7 @@
    id: 2686
    barcode: 6011
    description: November
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-11 18:32:57
    tool_type_id: 55
    active: 1
@@ -15954,7 +15924,7 @@
    id: 2687
    barcode: 6012
    description: December (Broken)
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-07 18:32:10
    tool_type_id: 55
    active: 1
@@ -15962,7 +15932,7 @@
    id: 2688
    barcode: 6015
    description: Quintillis
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-17 16:21:52
    tool_type_id: 55
    active: 1
@@ -15970,7 +15940,7 @@
    id: 2689
    barcode: 6016
    description: Sextillis
-   created_at: NULL
+   created_at: 2016-06-09 04:20:15
    updated_at: 2019-04-17 16:21:44
    tool_type_id: 55
    active: 1
@@ -17394,7 +17364,7 @@
    id: 2868
    barcode: 1607
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:37
    tool_type_id: WTF
    active: 6
@@ -17402,7 +17372,7 @@
    id: 2869
    barcode: 1608
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:37
    tool_type_id: WTF
    active: 6
@@ -17410,7 +17380,7 @@
    id: 2870
    barcode: 1609
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:37
    tool_type_id: WTF
    active: 6
@@ -17434,7 +17404,7 @@
    id: 2873
    barcode: 1612
    description: 3-Outlet
-   created_at: Orange & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:37
    tool_type_id: WTF
    active: 24
@@ -17442,7 +17412,7 @@
    id: 2874
    barcode: 1613
    description: 6-Outlet
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:37
    tool_type_id: WTF
    active: 24
@@ -17450,7 +17420,7 @@
    id: 2875
    barcode: 1615
    description: Porter-Cable
-   created_at: Gray
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:37
    tool_type_id: WTF
    active: 32
@@ -17594,9 +17564,7 @@
    id: 2893
    barcode: 1640
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:37
 2894:
    id: 2894
@@ -17778,7 +17746,7 @@
    id: 2916
    barcode: 1896
    description: Klein
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 27
@@ -17994,7 +17962,7 @@
    id: 2943
    barcode: 1951
    description: Task Force
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 26
@@ -18010,7 +17978,7 @@
    id: 2945
    barcode: 1953
    description: Task Force
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 26
@@ -18042,15 +18010,13 @@
    id: 2949
    barcode: 1957
    description: Kobalt
-   created_at: Long
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:38
 2950:
    id: 2950
    barcode: 1958
    description: Long
-   created_at: Red & Blue
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 26
@@ -18058,7 +18024,7 @@
    id: 2951
    barcode: 1959
    description: Mini
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 26
@@ -18066,7 +18032,7 @@
    id: 2952
    barcode: 1960
    description: Kobalt
-   created_at: Red & Blue
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 26
@@ -18090,7 +18056,7 @@
    id: 2955
    barcode: 1966
    description: Mini
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 26
@@ -18098,7 +18064,7 @@
    id: 2956
    barcode: 1967
    description: Mini
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 21
@@ -18114,23 +18080,19 @@
    id: 2958
    barcode: 1969
    description: Kobalt
-   created_at: Mini
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:38
 2959:
    id: 2959
    barcode: 1971
    description: Kobalt
-   created_at: Mini
-   updated_at: Red
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:38
 2960:
    id: 2960
    barcode: 1972
    description: Mini
-   created_at: Blue
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 21
@@ -18138,9 +18100,7 @@
    id: 2961
    barcode: 1973
    description: Kobalt
-   created_at: Mini
-   updated_at: Red & Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:38
 2962:
    id: 2962
@@ -18250,7 +18210,7 @@
    id: 2975
    barcode: 1995
    description: Mini
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 21
@@ -18258,7 +18218,7 @@
    id: 2976
    barcode: 1997
    description: Mini
-   created_at: Blue
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 21
@@ -18266,9 +18226,7 @@
    id: 2977
    barcode: 1999
    description: 2' Alvin
-   created_at: Silver
-   updated_at: Bendy
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-04-04 18:10:16
 2978:
    id: 2978
@@ -18282,7 +18240,7 @@
    id: 2979
    barcode: 2004
    description: Swanson
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 7
@@ -18290,7 +18248,7 @@
    id: 2980
    barcode: 2005
    description: Swanson
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 7
@@ -18298,7 +18256,7 @@
    id: 2981
    barcode: 2006
    description: Swanson
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 7
@@ -18306,7 +18264,7 @@
    id: 2982
    barcode: 2007
    description: Arrow T-50
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 22
@@ -18426,7 +18384,7 @@
    id: 2997
    barcode: 2029
    description: 8' Werner A-Frame
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 34
@@ -18434,7 +18392,7 @@
    id: 2998
    barcode: 2030
    description: 10' Werner A-Frame
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 34
@@ -18450,7 +18408,7 @@
    id: 3000
    barcode: 2045
    description: 8' Werner A-Frame
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:38
    tool_type_id: WTF
    active: 34
@@ -18482,31 +18440,25 @@
    id: 3004
    barcode: 2083
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:38
 3005:
    id: 3005
    barcode: 2087
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:38
 3006:
    id: 3006
    barcode: 2089
    description: Irwin
-   created_at: Small
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:39
 3007:
    id: 3007
    barcode: 2090
    description: Swanson
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 7
@@ -18522,7 +18474,7 @@
    id: 3009
    barcode: 2099
    description: Project Source
-   created_at: 1' Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 10
@@ -18530,7 +18482,7 @@
    id: 3010
    barcode: 2100
    description: Project Source
-   created_at: 1' Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 10
@@ -18538,7 +18490,7 @@
    id: 3011
    barcode: 2101
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 6
@@ -18554,7 +18506,7 @@
    id: 3013
    barcode: 2104
    description: 24' Task Force
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 10
@@ -18570,7 +18522,7 @@
    id: 3015
    barcode: 2129
    description: Clip on
-   created_at: Metal shade
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 6
@@ -18706,7 +18658,7 @@
    id: 3032
    barcode: 2191
    description: HDX
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 6
@@ -18722,7 +18674,7 @@
    id: 3034
    barcode: 2197
    description: 25' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 17
@@ -18730,7 +18682,7 @@
    id: 3035
    barcode: 2198
    description: 25' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 17
@@ -18738,7 +18690,7 @@
    id: 3036
    barcode: 2199
    description: 35' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 17
@@ -18746,23 +18698,19 @@
    id: 3037
    barcode: 2200
    description: Defiant
-   created_at: Small
-   updated_at: Black
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:39
 3038:
    id: 3038
    barcode: 2201
    description: Defiant
-   created_at: Small
-   updated_at: Gray
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:39
 3039:
    id: 3039
    barcode: 2202
    description: Defiant
-   created_at: Small Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 6
@@ -18786,7 +18734,7 @@
    id: 3042
    barcode: 2342
    description: Defiant
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 6
@@ -18794,7 +18742,7 @@
    id: 3043
    barcode: 2343
    description: Defiant
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 6
@@ -18802,7 +18750,7 @@
    id: 3044
    barcode: 2345
    description: Defiant
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 6
@@ -18826,7 +18774,7 @@
    id: 3047
    barcode: 2356
    description: Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 48
@@ -18834,7 +18782,7 @@
    id: 3048
    barcode: 2357
    description: Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 48
@@ -18842,7 +18790,7 @@
    id: 3049
    barcode: 2358
    description: Olympia
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 48
@@ -18850,7 +18798,7 @@
    id: 3050
    barcode: 2359
    description: Olympia
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 48
@@ -18858,7 +18806,7 @@
    id: 3051
    barcode: 2360
    description: Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 48
@@ -18866,7 +18814,7 @@
    id: 3052
    barcode: 2361
    description: Stanely TR-45
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 22
@@ -18874,7 +18822,7 @@
    id: 3053
    barcode: 2364
    description: Stanely TR-45
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 22
@@ -18882,7 +18830,7 @@
    id: 3054
    barcode: 2365
    description: Stanely TR-45
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 22
@@ -18890,7 +18838,7 @@
    id: 3055
    barcode: 2379
    description: 10' Black & Decker
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 17
@@ -18970,7 +18918,7 @@
    id: 3065
    barcode: 2425
    description: 3' Little Giant
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 34
@@ -18978,7 +18926,7 @@
    id: 3066
    barcode: 2426
    description: 6' Werner A-Frame
-   created_at: Green
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 34
@@ -19034,7 +18982,7 @@
    id: 3073
    barcode: 2524
    description: 8' Werner A-Frame
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:39
    tool_type_id: WTF
    active: 34
@@ -19082,7 +19030,7 @@
    id: 3079
    barcode: 2570
    description: Arrow T-50
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 22
@@ -19090,7 +19038,7 @@
    id: 3080
    barcode: 2577
    description: Klein
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 27
@@ -19098,7 +19046,7 @@
    id: 3081
    barcode: 2579
    description: Task Force
-   created_at: Red & Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 26
@@ -19106,7 +19054,7 @@
    id: 3082
    barcode: 2582
    description: 6' Werner A-Frame
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 34
@@ -19114,7 +19062,7 @@
    id: 3083
    barcode: 2583
    description: 6' Werner A-Frame
-   created_at: Green
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 34
@@ -19122,7 +19070,7 @@
    id: 3084
    barcode: 2584
    description: 6' Little Giant
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 34
@@ -19130,7 +19078,7 @@
    id: 3085
    barcode: 2585
    description: 6' Little Giant
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 34
@@ -19138,7 +19086,7 @@
    id: 3086
    barcode: 2586
    description: 6' A-Frame
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 34
@@ -19146,7 +19094,7 @@
    id: 3087
    barcode: 2588
    description: 16' Extendable
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 34
@@ -19170,15 +19118,13 @@
    id: 3090
    barcode: 2592
    description: Irwin
-   created_at: Large
-   updated_at: Blue
-   tool_type_id: WTF
+   created_at: 2016-06-09 04:20:15
    active: 2022-03-30 20:46:40
 3091:
    id: 3091
    barcode: 2599
    description: Bayco
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 6
@@ -19186,7 +19132,7 @@
    id: 3092
    barcode: 2602
    description: Bayco
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 6
@@ -19218,7 +19164,7 @@
    id: 3096
    barcode: 2613
    description: Dewalt
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 32
@@ -19226,7 +19172,7 @@
    id: 3097
    barcode: 2614
    description: Dewalt
-   created_at: Yellow
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 32
@@ -19250,7 +19196,7 @@
    id: 3100
    barcode: 2623
    description: Stanely TR-45
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 22
@@ -19258,7 +19204,7 @@
    id: 3101
    barcode: 2624
    description: Stanely TR-45
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 22
@@ -19266,7 +19212,7 @@
    id: 3102
    barcode: 2625
    description: 25' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 17
@@ -19274,7 +19220,7 @@
    id: 3103
    barcode: 2627
    description: 25' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 17
@@ -19282,7 +19228,7 @@
    id: 3104
    barcode: 2628
    description: 25' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 17
@@ -19290,7 +19236,7 @@
    id: 3105
    barcode: 2629
    description: 25' Stanely
-   created_at: Silver
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 17
@@ -19338,7 +19284,7 @@
    id: 3111
    barcode: 2642
    description: Milwaulkee
-   created_at: Red
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 31
@@ -19362,7 +19308,7 @@
    id: 3114
    barcode: 2708
    description: 3 Prong
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 45
@@ -19370,7 +19316,7 @@
    id: 3115
    barcode: 2709
    description: 2 Prong
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 45
@@ -19386,7 +19332,7 @@
    id: 3117
    barcode: 2713
    description: Stanley
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 12
@@ -19394,7 +19340,7 @@
    id: 3118
    barcode: 2714
    description: Stanley
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 12
@@ -19402,7 +19348,7 @@
    id: 3119
    barcode: 2715
    description: HDX
-   created_at: Orange
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 6
@@ -19410,7 +19356,7 @@
    id: 3120
    barcode: 2717
    description: Stanley
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 12
@@ -19418,7 +19364,7 @@
    id: 3121
    barcode: 2718
    description: Stanley
-   created_at: Black
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:40
    tool_type_id: WTF
    active: 12
@@ -20114,7 +20060,7 @@
    id: 3208
    barcode: 3602
    description: 1/4" Hex
-   created_at: 12V
+   created_at: 2022-03-30 20:46:41
    updated_at: 2022-03-30 20:46:41
    tool_type_id: WTF
    active: 43
@@ -20314,7 +20260,7 @@
    id: 3236
    barcode: 3630
    description: Red
-   created_at: Smooth Face
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:41
    tool_type_id: WTF
    active: 16
@@ -20322,7 +20268,7 @@
    id: 3237
    barcode: 3631
    description: Red
-   created_at: Smooth Face
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:41
    tool_type_id: WTF
    active: 16
@@ -20330,7 +20276,7 @@
    id: 3238
    barcode: 3632
    description: Red
-   created_at: Smooth Face
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:41
    tool_type_id: WTF
    active: 16
@@ -20338,7 +20284,7 @@
    id: 3239
    barcode: 3633
    description: Red
-   created_at: Smooth Face
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:41
    tool_type_id: WTF
    active: 16
@@ -20346,7 +20292,7 @@
    id: 3240
    barcode: 3634
    description: Red
-   created_at: Smooth Face
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-03-30 20:46:41
    tool_type_id: WTF
    active: 16
@@ -20994,7 +20940,7 @@
    id: 3321
    barcode: 3541
    description: Black/Red
-   created_at: small
+   created_at: 2016-06-09 04:20:15
    updated_at: 2022-04-03 17:55:22
    tool_type_id: WTF
    active: 21


### PR DESCRIPTION
In MySQL, migrations run in Rails 4.2 (Before 2023 in Binder) create tables with integer ids, while migrations Rails 6.0 and beyond create ids and references as bigints. This does not apply to SQLite which only has an integer type.

This difference means any future migrations relating a pre-2023 table to a post-2023 table (i.e. any important model to any new model) will succeed in SQLite, but fail in our MySQL production environment.

This commit addresses this by editing all pre-2023 migrations to 6.0 and removing any manually defined foreign key indexes (which are automatically created in 6.0). This commit additionally fixes the tools fixture file by ensuring all created_at entries are datetimes; this issue was uncovered by migrating tools in Rails 6.0