### PR TITLE
Update omniauth-rails_csrf_protection Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'cancancan'
 
 # Authenticate users with CMU Shibboleth
 gem 'omniauth'
-gem 'omniauth-rails_csrf_protection'
+gem 'omniauth-rails_csrf_protection', '~> 1.0'
 gem 'omniauth-saml'
 
 # Lookup CMU users in LDAP

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,9 +213,9 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth-rails_csrf_protection (0.1.2)
+    omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
+      omniauth (~> 2.0)
     omniauth-saml (2.1.2)
       omniauth (~> 2.1)
       ruby-saml (~> 1.17)
@@ -396,7 +396,7 @@ DEPENDENCIES
   mysql2
   net-ldap
   omniauth
-  omniauth-rails_csrf_protection
+  omniauth-rails_csrf_protection (~> 1.0)
   omniauth-saml
   pagy
   prettier_print


### PR DESCRIPTION
Version 0.1.2 causes authenticity token issues with omniauth > 2.0.