### PR TITLE
feat(build-progress): add structural/electrical build steps overview page

### DIFF
--- a/app/assets/stylesheets/binder.css
+++ b/app/assets/stylesheets/binder.css
@@ -207,12 +207,24 @@ li.tab {
   background: #2d9e2d;
 }
 
+.build-progress-grid td.step-approved:hover {
+  background: #3db83d;
+}
+
 .build-progress-grid td.step-pending {
   background: #cc2222;
 }
 
+.build-progress-grid td.step-pending:hover {
+  background: #e03333;
+}
+
 .build-progress-grid td.step-na {
   background: #e8e8e8;
+}
+
+.build-progress-grid td.step-na:hover {
+  background: #d4d4d4;
 }
 
 .build-progress-grid td.step-approved a.step-link,
@@ -222,6 +234,8 @@ li.tab {
   width: 100%;
   height: 100%;
   min-height: 1.5rem;
+  text-decoration: none;
+  border-bottom: none;
 }
 
 .build-progress-grid tbody tr:hover .org-col {

--- a/app/assets/stylesheets/binder.css
+++ b/app/assets/stylesheets/binder.css
@@ -215,6 +215,15 @@ li.tab {
   background: #e8e8e8;
 }
 
+.build-progress-grid td.step-approved a.step-link,
+.build-progress-grid td.step-pending a.step-link,
+.build-progress-grid td.step-na a.step-link {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 1.5rem;
+}
+
 .build-progress-grid tbody tr:hover .org-col {
   background: #f5f5f5;
 }

--- a/app/assets/stylesheets/binder.css
+++ b/app/assets/stylesheets/binder.css
@@ -168,6 +168,57 @@ li.tab {
   padding: 0.5rem;
 }
 
+.build-progress-grid {
+  border-collapse: collapse;
+  white-space: nowrap;
+}
+
+.build-progress-grid .org-col {
+  position: sticky;
+  left: 0;
+  background: white;
+  z-index: 1;
+  padding-right: 1rem;
+  min-width: 12rem;
+}
+
+.build-progress-grid thead .org-col {
+  z-index: 2;
+}
+
+.build-progress-grid .step-col {
+  width: 2rem;
+  padding: 0;
+  vertical-align: bottom;
+  text-align: left;
+}
+
+.build-progress-grid .step-col span {
+  display: block;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  padding: 0.4rem 0.3rem;
+  font-size: 0.8rem;
+  max-height: 10rem;
+  overflow: hidden;
+}
+
+.build-progress-grid td.step-approved {
+  background: #2d9e2d;
+}
+
+.build-progress-grid td.step-pending {
+  background: #cc2222;
+}
+
+.build-progress-grid td.step-na {
+  background: #e8e8e8;
+}
+
+.build-progress-grid tbody tr:hover .org-col {
+  background: #f5f5f5;
+}
+
 #nfc-fab {
   position: fixed;
   bottom: 1.5rem;

--- a/app/controllers/organization_build_statuses_controller.rb
+++ b/app/controllers/organization_build_statuses_controller.rb
@@ -4,12 +4,7 @@ class OrganizationBuildStatusesController < ApplicationController
   def index
     authorize! :manage, OrganizationBuildStatus
     @type = params[:type].presence_in(%w[structural electrical]) || 'structural'
-    @statuses =
-      OrganizationBuildStatus
-        .where(status_type: @type)
-        .includes(organization: {}, organization_build_steps: :approver)
-        .joins(:organization)
-        .order('organizations.name')
+    @statuses = load_statuses
     @step_titles = build_step_titles(@statuses)
     @step_lookup = build_step_lookup(@statuses)
   end
@@ -44,6 +39,24 @@ class OrganizationBuildStatusesController < ApplicationController
 
   def update_params
     params.expect(organization_build_status: [:notes])
+  end
+
+  def load_statuses
+    OrganizationBuildStatus
+      .where(status_type: @type)
+      .where(enabled_steps_exist)
+      .includes(organization: {}, organization_build_steps: :approver)
+      .joins(:organization)
+      .order('organizations.name')
+  end
+
+  def enabled_steps_exist
+    OrganizationBuildStep
+      .where('organization_build_steps.organization_build_status_id = organization_build_statuses.id')
+      .where(is_enabled: true)
+      .select('1')
+      .arel
+      .exists
   end
 
   def build_step_titles(statuses)

--- a/app/controllers/organization_build_statuses_controller.rb
+++ b/app/controllers/organization_build_statuses_controller.rb
@@ -10,6 +10,8 @@ class OrganizationBuildStatusesController < ApplicationController
         .includes(organization: {}, organization_build_steps: :approver)
         .joins(:organization)
         .order('organizations.name')
+    @step_titles = build_step_titles(@statuses)
+    @step_lookup = build_step_lookup(@statuses)
   end
 
   def show
@@ -42,5 +44,23 @@ class OrganizationBuildStatusesController < ApplicationController
 
   def update_params
     params.expect(organization_build_status: [:notes])
+  end
+
+  def build_step_titles(statuses)
+    statuses
+      .flat_map do |s|
+        s.organization_build_steps.select(&:is_enabled).map(&:title)
+      end
+      .uniq
+  end
+
+  def build_step_lookup(statuses)
+    statuses.each_with_object({}) do |status, hash|
+      hash[status.id] = status
+        .organization_build_steps
+        .select(&:is_enabled)
+        .group_by(&:title)
+        .transform_values(&:first)
+    end
   end
 end

--- a/app/controllers/organization_build_statuses_controller.rb
+++ b/app/controllers/organization_build_statuses_controller.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 class OrganizationBuildStatusesController < ApplicationController
+  def index
+    authorize! :manage, OrganizationBuildStatus
+    @type = params[:type].presence_in(%w[structural electrical]) || 'structural'
+    @statuses =
+      OrganizationBuildStatus
+        .where(status_type: @type)
+        .includes(organization: {}, organization_build_steps: :approver)
+        .joins(:organization)
+        .order('organizations.name')
+  end
+
   def show
     @build_status = OrganizationBuildStatus.find(params[:id])
 

--- a/app/controllers/organization_build_statuses_controller.rb
+++ b/app/controllers/organization_build_statuses_controller.rb
@@ -52,7 +52,9 @@ class OrganizationBuildStatusesController < ApplicationController
 
   def enabled_steps_exist
     OrganizationBuildStep
-      .where('organization_build_steps.organization_build_status_id = organization_build_statuses.id')
+      .where(
+        'organization_build_steps.organization_build_status_id = organization_build_statuses.id'
+      )
       .where(is_enabled: true)
       .select('1')
       .arel

--- a/app/helpers/application/navigation_helper.rb
+++ b/app/helpers/application/navigation_helper.rb
@@ -51,7 +51,18 @@ module Application::NavigationHelper # rubocop:disable Metrics/ModuleLength
         can: {
           action: :index,
           subject: Organization
-        }
+        },
+        children: [
+          {
+            label: 'Build Progress',
+            url: organization_build_statuses_path,
+            key: 'build_progress',
+            can: {
+              action: :manage,
+              subject: OrganizationBuildStatus
+            }
+          }
+        ]
       },
       {
         label: 'People',

--- a/app/views/organization_build_statuses/index.html.erb
+++ b/app/views/organization_build_statuses/index.html.erb
@@ -15,30 +15,38 @@
                 class: "btn#{' active' if @type == 'electrical'}" %>
   </div>
 
-  <table class="js-list">
-    <thead>
-      <tr>
-        <th>Organization</th>
-        <th>Steps</th>
-        <th>Approved</th>
-        <th>Pending</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @statuses.each do |status| %>
-        <% steps = status.organization_build_steps.select(&:is_enabled) %>
-        <% approved = steps.select { |s| s.approver.present? } %>
-        <% pending = steps.reject { |s| s.approver.present? } %>
+  <div style="overflow-x: auto;">
+    <table class="build-progress-grid">
+      <thead>
         <tr>
-          <td>
-            <%= link_to status.organization.name,
-                        organization_organization_build_status_path(status.organization, status) %>
-          </td>
-          <td><%= steps.count %></td>
-          <td><%= approved.count %></td>
-          <td><%= pending.count %></td>
+          <th class="org-col">Organization</th>
+          <% @step_titles.each do |title| %>
+            <th class="step-col"><span><%= title %></span></th>
+          <% end %>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <% @statuses.each do |status| %>
+          <tr>
+            <td class="org-col">
+              <%= link_to status.organization.name,
+                          organization_organization_build_status_path(status.organization, status) %>
+            </td>
+            <% @step_titles.each do |title| %>
+              <% step = @step_lookup[status.id][title] %>
+              <% css =
+                   if step.nil?
+                     'step-na'
+                   elsif step.approver.present?
+                     'step-approved'
+                   else
+                     'step-pending'
+                   end %>
+              <td class="<%= css %>" title="<%= title %>"></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/organization_build_statuses/index.html.erb
+++ b/app/views/organization_build_statuses/index.html.erb
@@ -1,0 +1,44 @@
+<% update_document_title(add: 'Build Progress') %>
+<% update_breadcrumbs(add: link_to('Organizations', organizations_path)) %>
+<% update_breadcrumbs(add: 'Build Progress') %>
+<% nav(active: 'organizations') %>
+
+<div class="content wide">
+  <h1>Build Progress</h1>
+
+  <div style="margin-bottom: 1rem;">
+    <%= link_to 'Structural',
+                organization_build_statuses_path(type: 'structural'),
+                class: "btn#{' active' if @type == 'structural'}" %>
+    <%= link_to 'Electrical',
+                organization_build_statuses_path(type: 'electrical'),
+                class: "btn#{' active' if @type == 'electrical'}" %>
+  </div>
+
+  <table class="js-list">
+    <thead>
+      <tr>
+        <th>Organization</th>
+        <th>Steps</th>
+        <th>Approved</th>
+        <th>Pending</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @statuses.each do |status| %>
+        <% steps = status.organization_build_steps.select(&:is_enabled) %>
+        <% approved = steps.select { |s| s.approver.present? } %>
+        <% pending = steps.reject { |s| s.approver.present? } %>
+        <tr>
+          <td>
+            <%= link_to status.organization.name,
+                        organization_organization_build_status_path(status.organization, status) %>
+          </td>
+          <td><%= steps.count %></td>
+          <td><%= approved.count %></td>
+          <td><%= pending.count %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/organization_build_statuses/index.html.erb
+++ b/app/views/organization_build_statuses/index.html.erb
@@ -4,49 +4,54 @@
 <% nav(active: 'organizations') %>
 
 <div class="content wide">
-  <h1>Build Progress</h1>
+  <div>
+    <h1>Build Progress</h1>
 
-  <div style="margin-bottom: 1rem;">
-    <%= link_to 'Structural',
-                organization_build_statuses_path(type: 'structural'),
-                class: "btn#{' active' if @type == 'structural'}" %>
-    <%= link_to 'Electrical',
-                organization_build_statuses_path(type: 'electrical'),
-                class: "btn#{' active' if @type == 'electrical'}" %>
-  </div>
+    <div style="margin-bottom: 1rem;">
+      <%= link_to 'Structural',
+                  organization_build_statuses_path(type: 'structural'),
+                  class: "btn#{' active' if @type == 'structural'}" %>
+      <%= link_to 'Electrical',
+                  organization_build_statuses_path(type: 'electrical'),
+                  class: "btn#{' active' if @type == 'electrical'}" %>
+    </div>
 
-  <div style="overflow-x: auto;">
-    <table class="build-progress-grid">
-      <thead>
-        <tr>
-          <th class="org-col">Organization</th>
-          <% @step_titles.each do |title| %>
-            <th class="step-col"><span><%= title %></span></th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @statuses.each do |status| %>
+    <div style="overflow-x: auto;">
+      <table class="build-progress-grid">
+        <thead>
           <tr>
-            <td class="org-col">
-              <%= link_to status.organization.name,
-                          organization_organization_build_status_path(status.organization, status) %>
-            </td>
+            <th class="org-col">Organization</th>
             <% @step_titles.each do |title| %>
-              <% step = @step_lookup[status.id][title] %>
-              <% css =
-                   if step.nil?
-                     'step-na'
-                   elsif step.approver.present?
-                     'step-approved'
-                   else
-                     'step-pending'
-                   end %>
-              <td class="<%= css %>" title="<%= title %>"></td>
+              <th class="step-col"><span><%= title %></span></th>
             <% end %>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @statuses.each do |status| %>
+            <% status_path =
+                 organization_organization_build_status_path(status.organization, status) %>
+            <tr>
+              <td class="org-col">
+                <%= link_to status.organization.name, status_path %>
+              </td>
+              <% @step_titles.each do |title| %>
+                <% step = @step_lookup[status.id][title] %>
+                <% css =
+                     if step.nil?
+                       'step-na'
+                     elsif step.approver.present?
+                       'step-approved'
+                     else
+                       'step-pending'
+                     end %>
+                <td class="<%= css %>" title="<%= title %>">
+                  <%= link_to '', status_path, class: 'step-link' %>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/views/organization_build_statuses/index.html.erb
+++ b/app/views/organization_build_statuses/index.html.erb
@@ -16,42 +16,40 @@
                   class: "btn#{' active' if @type == 'electrical'}" %>
     </div>
 
-    <div style="overflow-x: auto;">
-      <table class="build-progress-grid">
-        <thead>
+    <table class="build-progress-grid">
+      <thead>
+        <tr>
+          <th class="org-col">Organization</th>
+          <% @step_titles.each do |title| %>
+            <th class="step-col"><span><%= title %></span></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% @statuses.each do |status| %>
+          <% status_path =
+               organization_organization_build_status_path(status.organization, status) %>
           <tr>
-            <th class="org-col">Organization</th>
+            <td class="org-col">
+              <%= link_to status.organization.name, status_path %>
+            </td>
             <% @step_titles.each do |title| %>
-              <th class="step-col"><span><%= title %></span></th>
+              <% step = @step_lookup[status.id][title] %>
+              <% css =
+                   if step.nil?
+                     'step-na'
+                   elsif step.approver.present?
+                     'step-approved'
+                   else
+                     'step-pending'
+                   end %>
+              <td class="<%= css %>" title="<%= title %>">
+                <%= link_to '', status_path, class: 'step-link' %>
+              </td>
             <% end %>
           </tr>
-        </thead>
-        <tbody>
-          <% @statuses.each do |status| %>
-            <% status_path =
-                 organization_organization_build_status_path(status.organization, status) %>
-            <tr>
-              <td class="org-col">
-                <%= link_to status.organization.name, status_path %>
-              </td>
-              <% @step_titles.each do |title| %>
-                <% step = @step_lookup[status.id][title] %>
-                <% css =
-                     if step.nil?
-                       'step-na'
-                     elsif step.approver.present?
-                       'step-approved'
-                     else
-                       'step-pending'
-                     end %>
-                <td class="<%= css %>" title="<%= title %>">
-                  <%= link_to '', status_path, class: 'step-link' %>
-                </td>
-              <% end %>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,8 @@ Rails.application.routes.draw do
   post 'toggle_downtime', to: 'downtime#toggle'
 
   # TODO: Confirm everything below
+  resources :organization_build_statuses, only: [:index]
+
   resources :organizations do
     resources :organization_build_statuses, only: %i[show edit update] do
       resources :organization_build_steps,


### PR DESCRIPTION
Adds a spreadsheet-style overview page at /organization_build_statuses showing all orgs as rows and each build step as a column. Green = approved, red = pending, grey = step doesn't exist for that org. Restricted to SCC members via CanCan.