### PR TITLE
feat(queues): add Remove & View Inspections button

### DIFF
--- a/app/controllers/organization_timeline_entries_controller.rb
+++ b/app/controllers/organization_timeline_entries_controller.rb
@@ -88,8 +88,8 @@ class OrganizationTimelineEntriesController < ApplicationController
   end
 
   def queues
-    @electrical = OrganizationTimelineEntry.electrical.current
-    @structural = OrganizationTimelineEntry.structural.current
+    @electrical = OrganizationTimelineEntry.electrical.current.includes(organization: :organization_build_statuses)
+    @structural = OrganizationTimelineEntry.structural.current.includes(organization: :organization_build_statuses)
   end
 
   def history

--- a/app/controllers/organization_timeline_entries_controller.rb
+++ b/app/controllers/organization_timeline_entries_controller.rb
@@ -88,8 +88,14 @@ class OrganizationTimelineEntriesController < ApplicationController
   end
 
   def queues
-    @electrical = OrganizationTimelineEntry.electrical.current.includes(organization: :organization_build_statuses)
-    @structural = OrganizationTimelineEntry.structural.current.includes(organization: :organization_build_statuses)
+    @electrical =
+      OrganizationTimelineEntry.electrical.current.includes(
+        organization: :organization_build_statuses
+      )
+    @structural =
+      OrganizationTimelineEntry.structural.current.includes(
+        organization: :organization_build_statuses
+      )
   end
 
   def history

--- a/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
+++ b/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
@@ -16,18 +16,22 @@
           <td><%= h entry.description %></td>
           <td><%= entry.started_at %></td>
           <td><%= format_duration(Time.zone.now - entry.started_at) %></td>
-          <td>
+          <td style="white-space: nowrap">
             <% if can?(:end, entry) %>
               <% build_status =
                    entry.organization.organization_build_statuses.find_by(
                      status_type: entry.entry_type,
                    ) %>
-              <%= form_tag end_organization_timeline_entry_path(entry), method: :put do %>
+              <%= form_tag end_organization_timeline_entry_path(entry),
+                           method: :put,
+                           style: 'display: inline' do %>
                 <%= hidden_field_tag 'url', request.original_fullpath %>
                 <%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %>
               <% end %>
               <% if build_status %>
-                <%= form_tag end_organization_timeline_entry_path(entry), method: :put do %>
+                <%= form_tag end_organization_timeline_entry_path(entry),
+                             method: :put,
+                             style: 'display: inline' do %>
                   <%= hidden_field_tag 'url',
                                        organization_organization_build_status_path(
                                          entry.organization,

--- a/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
+++ b/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
@@ -18,7 +18,24 @@
           <td><%= format_duration(Time.zone.now - entry.started_at) %></td>
           <td>
             <% if can?(:end, entry) %>
-              <%= form_tag end_organization_timeline_entry_path(entry), method: :put do %><%= hidden_field_tag 'url', request.original_fullpath %><%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %><% end %>
+              <% build_status =
+                   entry.organization.organization_build_statuses.find_by(
+                     status_type: entry.entry_type,
+                   ) %>
+              <%= form_tag end_organization_timeline_entry_path(entry), method: :put do %>
+                <%= hidden_field_tag 'url', request.original_fullpath %>
+                <%= submit_tag 'Remove', class: 'btn btn-xs btn-danger' %>
+              <% end %>
+              <% if build_status %>
+                <%= form_tag end_organization_timeline_entry_path(entry), method: :put do %>
+                  <%= hidden_field_tag 'url',
+                                       organization_organization_build_status_path(
+                                         entry.organization,
+                                         build_status,
+                                       ) %>
+                  <%= submit_tag 'Remove & View Inspections', class: 'btn btn-xs btn-danger' %>
+                <% end %>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
+++ b/app/views/organization_timeline_entries/_organization_timeline_entries.html.erb
@@ -20,7 +20,7 @@
             <% if can?(:end, entry) %>
               <% build_status =
                    entry.organization.organization_build_statuses.find_by(
-                     status_type: entry.entry_type,
+                     status_type: entry.entry_type
                    ) %>
               <%= form_tag end_organization_timeline_entry_path(entry),
                            method: :put,
@@ -35,7 +35,7 @@
                   <%= hidden_field_tag 'url',
                                        organization_organization_build_status_path(
                                          entry.organization,
-                                         build_status,
+                                         build_status
                                        ) %>
                   <%= submit_tag 'Remove & View Inspections', class: 'btn btn-xs btn-danger' %>
                 <% end %>


### PR DESCRIPTION
Adds a **Remove & View Inspections** button alongside the existing Remove button on each queue entry. It removes the org from the queue and redirects to their matching structural/electrical build status page.

Also eager loads `organization_build_statuses` to avoid N+1 on the queue page.