### PR TITLE
feat(tools): restore focus to last used input after form submit

### DIFF
--- a/app/controllers/tools/checkin_controller.rb
+++ b/app/controllers/tools/checkin_controller.rb
@@ -4,19 +4,19 @@ class Tools::CheckinController < ApplicationController
   def create
     tool = Tool.find_by(barcode: params[:barcode])
     store_checkin_in_session(tool)
-    redirect_to checkout_tools_path
+    redirect_to checkout_tools_path(focus: 'checkin_barcode')
   end
 
   def update
     @tool = Tool.find_by(barcode: params[:barcode])
     if @tool.blank?
-      redirect_to checkout_tools_path,
+      redirect_to checkout_tools_path(focus: 'checkin_barcode'),
                   alert: "Tool #{params[:barcode]} does not exist."
     else
       checkin_tool
     end
   rescue StandardError
-    redirect_to checkout_tools_path,
+    redirect_to checkout_tools_path(focus: 'checkin_barcode'),
                 alert: "Tool #{params[:barcode]} was never checked out."
   end
 
@@ -67,7 +67,7 @@ class Tools::CheckinController < ApplicationController
     data = org_and_remaining_tools
     process_checkout
     get_checkin_tool_summary(data[:org], data[:remaining])
-    redirect_to checkout_tools_path,
+    redirect_to checkout_tools_path(focus: 'checkin_barcode'),
                 notice: "Tool #{params[:barcode]} successfully checked in."
   end
 end

--- a/app/controllers/tools/checkouts_controller.rb
+++ b/app/controllers/tools/checkouts_controller.rb
@@ -8,7 +8,7 @@ class Tools::CheckoutsController < ApplicationController
     session[:tools] ||= []
     tool = Tool.find_by(barcode: params[:barcode])
     update_tool_session(tool)
-    redirect_to checkout_tools_path
+    redirect_to checkout_tools_path(focus: focus_param)
   end
 
   def remove
@@ -20,7 +20,7 @@ class Tools::CheckoutsController < ApplicationController
     store_borrower_in_session
     return redirect_to params[:url] if params[:url].present?
 
-    redirect_to checkout_tools_path
+    redirect_to checkout_tools_path(focus: focus_param)
   end
 
   def reset
@@ -55,6 +55,10 @@ class Tools::CheckoutsController < ApplicationController
   end
 
   private
+
+  def focus_param
+    params[:focus].presence_in(%w[checkout_barcode participant_search checkin_barcode])
+  end
 
   def update_tool_session(tool)
     if tool.nil?

--- a/app/views/tools/checkouts/_checkin_form.html.erb
+++ b/app/views/tools/checkouts/_checkin_form.html.erb
@@ -1,7 +1,14 @@
 <h3>What is being returned?</h3>
 <%= form_tag checkin_tools_path do %>
-  <%= label_tag(:barcode, 'Scan or Type Tool Barcode [Enter]') %>
-  <%= text_field_tag(:barcode, nil, autocomplete: :off) %>
+  <%= hidden_field_tag :focus, 'checkin_barcode' %>
+  <%= label_tag(:checkin_barcode, 'Scan or Type Tool Barcode [Enter]') %>
+  <%= text_field_tag(
+        :barcode,
+        nil,
+        id: 'checkin_barcode',
+        autocomplete: :off,
+        autofocus: params[:focus] == 'checkin_barcode'
+      ) %>
 <% end %>
 
 <% if session[:checkin_summary].present? %>

--- a/app/views/tools/checkouts/_checkout_form.html.erb
+++ b/app/views/tools/checkouts/_checkout_form.html.erb
@@ -11,8 +11,15 @@
 </ul>
 <%= form_tag add_tools_path do %>
   <%= hidden_field_tag :url, params[:url] %>
-  <%= label_tag(:barcode, 'Scan or Type Tool Barcode [Enter]') %>
-  <%= text_field_tag(:barcode, nil, autocomplete: :off, autofocus: true) %>
+  <%= hidden_field_tag :focus, 'checkout_barcode' %>
+  <%= label_tag(:checkout_barcode, 'Scan or Type Tool Barcode [Enter]') %>
+  <%= text_field_tag(
+        :barcode,
+        nil,
+        id: 'checkout_barcode',
+        autocomplete: :off,
+        autofocus: %w[participant_search checkin_barcode].exclude?(params[:focus])
+      ) %>
 <% end %>
 
 <h3>The Borrower</h3>
@@ -52,8 +59,14 @@
   <% end %>
 <% else %>
   <%= form_tag checkout_participant_tools_path do %>
+    <%= hidden_field_tag :focus, 'participant_search' %>
     <%= label_tag(:participant_search, 'Tap/Swipe/Type Andrew ID [Enter]') %>
-    <%= text_field_tag(:participant_search, nil, autocomplete: :off, autofocus: true) %>
+    <%= text_field_tag(
+          :participant_search,
+          nil,
+          autocomplete: :off,
+          autofocus: params[:focus] == 'participant_search'
+        ) %>
   <% end %>
 <% end %>
 <p class="alignright"><%= link_to 'Reset', reset_tools_path, class: 'cta' %></p>


### PR DESCRIPTION
After submitting the tool barcode, participant search, or checkin barcode forms, focus returns to the input that was just used rather than always defaulting to the checkout barcode field.

Each form passes a `focus` param through the redirect (whitelisted in the controller). The view applies `autofocus` conditionally based on that param. No JS required.