### PR TITLE
feat(applets): require SCC authorization for PPE applets

### DIFF
--- a/app/controllers/applets/ppe_collection_controller.rb
+++ b/app/controllers/applets/ppe_collection_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Applets::PPECollectionController < ApplicationController
+  before_action :require_scc
+
   def index
     return unless params[:hardhat_barcode]
 
@@ -40,5 +42,9 @@ class Applets::PPECollectionController < ApplicationController
 
   def no_current_checkout?
     @hardhat.checkouts.blank? || @hardhat.checkouts.current.blank?
+  end
+
+  def require_scc
+    authorize! :update, Checkout
   end
 end

--- a/app/controllers/applets/ppe_distribution_controller.rb
+++ b/app/controllers/applets/ppe_distribution_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Applets::PPEDistributionController < ApplicationController
+  before_action :require_scc
+
   def index
     case params[:step]
     when '1'
@@ -119,6 +121,10 @@ class Applets::PPEDistributionController < ApplicationController
     return false if @hardhat.blank?
 
     true
+  end
+
+  def require_scc
+    authorize! :create, Checkout
   end
 
   def step_three


### PR DESCRIPTION
## Summary

- PPE collection (`authorize! :update, Checkout`) and distribution (`authorize! :create, Checkout`) were missing authorization checks despite performing SCC-only operations
- Follows the existing `push_broadcast` pattern (`before_action :require_scc`)
- Wristband lookup and push broadcast were already correctly authorized

## Test plan

- [ ] Non-SCC users are redirected away from `/ppe-collection` and `/ppe-distribution`
- [ ] SCC users can still access and use both applets normally